### PR TITLE
Prevent chktek warning in vim

### DIFF
--- a/inkscapefigures/main.py
+++ b/inkscapefigures/main.py
@@ -26,7 +26,7 @@ def create_latex(name, title, indent=0):
         r"\begin{figure}[ht]",
         r"    \centering",
         rf"    \incfig{{{name}}}",
-        rf"    \caption{{{title.strip()}}}",
+        rf"    \caption{{{title.strip()}}}%",
         rf"    \label{{fig:{name}}}",
         r"\end{figure}"]
 


### PR DESCRIPTION
I get a warning "Delete this space to maintain correct pagereferences." (chktex warning #24) at the line creating the label. The "%" at the end of the caption line would prevent this warning.

Maybe there would also be a way to change the default latex figure inclusion template (e.g., for having 2 spaces instead of 4) ?