### PR TITLE
add parameter for \incfig to resize figure

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the following code to the preamble of your LateX document.
 \pdfsuppresswarningpagegroup=1
 ```
 
-**Remark**: By defaut we use `\incfig{figname}` to include an `.pdf_tex` figure. But when you use `minipage` environment or the `\columnwidth`
+**Remark**: By defaut we use `\incfig{figname}` to include a `.pdf_tex` figure. But when you use `minipage` environment or the `\columnwidth`
 is just too big for the figure. You can use `\incfig[0.3]{figname}` to set the figure width to `0.3\columnwidth`.
 
 The settings above assumes the following directory structure:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add the following code to the preamble of your LateX document.
 **Remark**: By defaut we use `\incfig{figname}` to include a `.pdf_tex` figure. But when you use `minipage` environment or the `\columnwidth`
 is just too big for the figure. You can use `\incfig[0.3]{figname}` to set the figure width to `0.3\columnwidth`.
 
-The settings above assumes the following directory structure:
+The settings above assume the following directory structure:
 
 ```
 master.tex

--- a/README.md
+++ b/README.md
@@ -26,14 +26,18 @@ Add the following code to the preamble of your LateX document.
 \usepackage{transparent}
 \usepackage{xcolor}
 
-\newcommand{\incfig}[1]{%
-    \def\svgwidth{\columnwidth}
-    \import{./figures/}{#1.pdf_tex}
+\newcommand{\incfig}[2][0.3]{%
+    \def\svgwidth{#1\columnwidth}
+    \import{./figures/}{#2.pdf_tex}
 }
+
 \pdfsuppresswarningpagegroup=1
 ```
 
-This assumes the following directory structure:
+**Remark**: By defaut we use `\incfig{figname}` to include an `.pdf_tex` figure. But when you use `minipage` environment or the `\columnwidth`
+is just too big for the figure. You can use `\incfig[0.3]{figname}` to set the figure width to `0.3\columnwidth`.
+
+The settings above assumes the following directory structure:
 
 ```
 master.tex


### PR DESCRIPTION
When I use minipage or the figure is a small one, it's very inconvenient to adjust the size. There are 2 solutions, one is set the size when drawing in inkscape. Another is adding parameter for 
`\incfig`. So I change the macro so that people can change the size when editing their tex files, and 
the change is completely compatible with the original one, you can still use `\incfig{figname}` to include figures.
(P.S. I made some typos, so I commited 3 times, you can just ignore the first 2 commits)