### PR TITLE
implemented real check for macos vs linux

### DIFF
--- a/inkscapefigures/main.py
+++ b/inkscapefigures/main.py
@@ -15,12 +15,12 @@ from appdirs import user_config_dir
 
 SYSTEM_NAME = platform.system()
 
-try:
+if (SYSTEM_NAME == 'Darwin'): #check whether the system is macos
+    HAS_INOTIFY = False
+else:
     import inotify.adapters
     from inotify.constants import IN_CLOSE_WRITE
     HAS_INOTIFY = True
-except ImportError:
-    HAS_INOTIFY = False
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
 log = logging.getLogger('inkscape-figures')


### PR DESCRIPTION
The current system loads fswatch only when inotify fails to import. The try except only catches ImportError. On my system (macos Mojave) inotify failed to load, throwing an AttributeError, thus crashing the program. 
Instead of catching all types of errors (which would catch legitimate errors on linux), it seemed better to directly check the os to decide whether fswatch (for macos) of inotify (for linux) should be used.