### PR TITLE
Edited cli options to support Inkscape 1.1

### DIFF
--- a/inkscapefigures/main.py
+++ b/inkscapefigures/main.py
@@ -128,25 +128,34 @@ def maybe_recompile_figure(filepath):
 
     inkscape_version = subprocess.check_output(['inkscape', '--version'], universal_newlines=True)
     log.debug(inkscape_version)
-    inkscape_version_number = int(inkscape_version.split()[1][0])
+    inkscape_version_number = float(inkscape_version.split()[1].split('-')[0])
 
-    if inkscape_version_number != 0:
-        command = [
-            'inkscape', filepath,
-            '--export-area-page',
-            '--export-dpi', '300',
-            '--export-type=pdf', 
-            '--export-latex',
-            '--export-file', pdf_path
-        ]
-    else:
+    if inkscape_version_number < 1:
         command = [
             'inkscape',
             '--export-area-page',
             '--export-dpi', '300',
             '--export-pdf', pdf_path,
             '--export-latex', filepath
-        ]
+            ]
+    elif inkscape_version_number < 1.1:
+        command = [
+            'inkscape', filepath,
+            '--export-area-page',
+            '--export-dpi', '300',
+            '--export-type=pdf',
+            '--export-latex',
+            '--export-file', pdf_path
+            ]
+    else:
+        command = [
+            'inkscape', filepath,
+            '--export-area-page',
+            '--export-dpi', '300',
+            '--export-type=pdf',
+            '--export-latex',
+            '--export-filename', pdf_path
+            ]
 
     log.debug('Running command:')
     log.debug(' '.join(str(e) for e in command))


### PR DESCRIPTION
Inkscape renamed CLI option `--export-file` to `--export-filename` (or `-o`) somewhere inbetween versions `1.0` and `1.1`.

This adds handling for inkscape version `1.1`, as described in issue #18.

This also changes inkscape version parsing and gives us much more room for handling different inkscape versions in a different ways.

Tested with `Inkscape 1.1-dev (3a9df5bcce, 2020-03-18)`

This fixes #18.