### PR TITLE
Fixed talking to inkscape >1.0.0

### DIFF
--- a/inkscapefigures/main.py
+++ b/inkscapefigures/main.py
@@ -149,15 +149,6 @@ def maybe_recompile_figure(filepath):
             '--export-pdf', pdf_path,
             '--export-latex', filepath
             ]
-    elif inkscape_version_number < [1, 1, 0]:
-        command = [
-            'inkscape', filepath,
-            '--export-area-page',
-            '--export-dpi', '300',
-            '--export-type=pdf',
-            '--export-latex',
-            '--export-file', pdf_path
-            ]
     else:
         command = [
             'inkscape', filepath,


### PR DESCRIPTION
Inkscape changed it's API, it's slightly different
to the one used in development versions.

This changes construction of command flags passed to inkscape.

This will probably break development version of inkscape between
1.0.0-dev and 1.1.0-dev, but this shouldn't be an issue because
it's old version nobody should be using anyway.

This fixes https://github.com/gillescastel/inkscape-figures/issues/25