### PR TITLE
Fix: clipboard trigger on edit

### DIFF
--- a/inkscapefigures/main.py
+++ b/inkscapefigures/main.py
@@ -305,6 +305,7 @@ def edit(root):
         path = files[index]
         add_root(figures)
         inkscape(path)
+        pyperclip.copy(latex_template(path.stem, beautify(path.stem)))
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
Adds copying to clipboard on 'inkscape-figures edit' when the file is selected.
