### PR TITLE
Wait and retry when inkscape --version fails (+ incorporate other pull requests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ More information in this [blog post](https://castel.dev/post/lecture-notes-2/).
 You need Python >= 3.7, as well as a picker. Current supported pickers are:
 
 * [rofi](https://github.com/davatorium/rofi) on Linux systems
-* [choose](https://github.com/chipsenkbeil/choose) on MacOS
+* [choose](https://github.com/chipsenkbeil/choose) on macOS
+* [fswatch](https://github.com/emcrisostomo/fswatch) on macOS
 
 ## Installation
 

--- a/inkscapefigures/main.py
+++ b/inkscapefigures/main.py
@@ -6,6 +6,7 @@ import logging
 import subprocess
 import textwrap
 import warnings
+import time
 from pathlib import Path
 from shutil import copy
 from daemonize import Daemonize
@@ -128,7 +129,13 @@ def maybe_recompile_figure(filepath):
     pdf_path = filepath.parent / (filepath.stem + '.pdf')
     name = filepath.stem
 
-    inkscape_version = subprocess.check_output(['inkscape', '--version'], universal_newlines=True)
+    try:
+        inkscape_version = subprocess.check_output(['inkscape', '--version'], universal_newlines=True)
+    except subprocess.CalledProcessError:
+        log.info('inkscape --version failed, retry later')
+        time.sleep(5)
+        return maybe_recompile_figure(filepath)
+
     log.debug(inkscape_version)
 
     # Convert


### PR DESCRIPTION
Thanks for the program!

Unfortunately there's just a minor bug, but it is pretty annoying: sometimes Inkscape crashes, then `inkscape --version` trying to connect to the main inkscape process will also crash (I think that's what happens? it just prints out the following

```
terminate called after throwing an instance of 'Gio::DBus::Error'
```

)

While waiting for inkscape bug to be fixed, it seems easiest to just catch the thing and retry later.

As a disadvantage, if inkscape is in fact not installed, now the program will retry `inkscape --version` every 5 seconds. But I think this is not an issue in practice.

--------

Also incorporate some other pull requests to this repository for the convenience of anyone who comes across my fork…